### PR TITLE
Fix for variable {{ domain }}

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Ansible Role: Containerized WordPress
 
 This Ansible playbook will Deploy & run Docker Compose project for WordPress instance. It will also configure Let's Encrypt certificates for specified domain. It consists of 3 separate containers running:
 * WordPress
-* Nginx (enabled with Let's Encrpt HTTPS encryption)
+* Nginx (enabled with Let's Encrypt HTTPS encryption)
 * MySQL
 
 This role was created as part of [containerized-wordpress-project](https://github.com/AdnanHodzic/containerized-wordpress-project)

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -13,6 +13,12 @@ galaxy_info:
   - name: Debian
     versions:
     - all
+  - name: CentOS
+    versions:
+    - all
+  - name: RedHat
+    versions: 
+    - all 
 
   galaxy_tags:
     - development
@@ -21,6 +27,9 @@ galaxy_info:
     - compose
     - ubuntu
     - debian
+    - centos
+    - redhat
+    - rhel
     - wordpress
     - nginx
     - mariadb

--- a/templates/docker-compose.j2
+++ b/templates/docker-compose.j2
@@ -13,7 +13,7 @@ services:
     environment:
       CLIENT_MAX_BODY_SIZE: '100M'
       GZIP: 'on'
-      DOMAINS: 'test.foolcontrol.org -> http://wordpress:80'
+      DOMAINS: '{{ domain }} -> http://wordpress:80'
       STAGE: '{{ stage }}'
     links:
       - wordpress


### PR DESCRIPTION
Hello Adnan! I made the roles compatible for RHEL distro's, during this I noticed a forgotten variable. {{ domain }} wasn't called in the docker-compose template, but your testdomain in text. I tested it multiple times, it works with this adjustment. Also fixed a little typo I crossed by. Best regards, Martzen 